### PR TITLE
changed update file tag to main

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-files:
-    uses: boldlink/terraform-module-support/.github/workflows/update.yaml@1.0.0
+    uses: boldlink/terraform-module-support/.github/workflows/update.yaml@main
     secrets:
       AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
       SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "team_closed" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 5.12.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | 5.13.0 |
 
 ## Modules
 


### PR DESCRIPTION
This PR changes update workflow tag to main.
This will ensure only the recent workflow is will run.
It also ensures no manual changes will be done to the update file in case there is an update to the reusable workflow